### PR TITLE
Fix convert_k_to_int logic

### DIFF
--- a/openbinn/experiment_utils.py
+++ b/openbinn/experiment_utils.py
@@ -20,14 +20,21 @@ def convert_k_to_int(k, n_feat):
     """
     if k == -1:
         return n_feat
-    if not isinstance(k, int):
-        if isinstance(k, float):
-            if 0 < k < 1:
-                return np.ceil(k * n_feat).astype(int)
-            else:
-                raise ValueError(f'Float value for k {k} must be between 0 and 1')
+
+    # Integer k specifies the exact number of features
+    if isinstance(k, int):
+        if k <= 0:
+            raise ValueError(f'Integer value for k {k} must be positive')
+        return k
+
+    # Float k indicates a fraction of the total features
+    if isinstance(k, float):
+        if 0 < k < 1:
+            return int(np.ceil(k * n_feat))
         else:
-            raise ValueError(f'Invalid type for k: {type(k)}')
+            raise ValueError(f'Float value for k {k} must be between 0 and 1')
+
+    raise ValueError(f'Invalid type for k: {type(k)}')
 
 def load_parameterized_file(prefix, params, extension='.npy'):
     """


### PR DESCRIPTION
## Summary
- handle integer and fractional k values in `convert_k_to_int`

## Testing
- `python -m py_compile openbinn/experiment_utils.py`
- `grep -v '\._' pyfiles.txt | xargs python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_6843f67f8f508322acd754d1b5b4e09e