### PR TITLE
Stub unused explainers

### DIFF
--- a/openbinn/explainers/catalog/ebp/ebp.py
+++ b/openbinn/explainers/catalog/ebp/ebp.py
@@ -1,40 +1,17 @@
+"""Placeholder for the unused EBP explainer."""
+
 import torch
 from ...api import BaseExplainer
-from torchray.attribution.excitation_backprop import excitation_backprop
 
 
 class EBP(BaseExplainer):
-    """
-    Provides excitation backpropagation.
-    Excitation backprop paper: https://arxiv.org/abs/1608.00507
-    TorchRay reference: https://facebookresearch.github.io/TorchRay/_modules/torchray/attribution/excitation_backprop.html
-    """
-    
-    def __init__(self, model):
-        """
-        Args:
-            model (torch.nn.Module): model on which to make predictions
-        """
-        super(EBP, self).__init__(model)
+    """Empty implementation for Excitation Backpropagation."""
 
-    def get_explanations(self, x: torch.Tensor, label=None):
-        """
-        Explain an instance prediction.
-        Args:
-            x (torch.Tensor, [N x 1 x d] for tabular instance; [N x m x n x d] for image instance): feature tensor
-            label (torch.Tensor, [N x ...]): labels to explain
-        Returns:
-            exp (torch.Tensor, [N x 1 x d] for tabular instance; [N x m x n x d] for image instance: instance level explanation):
-        """
-        self.model.eval()
-        self.model.zero_grad()
+    def __init__(self, model, *args, **kwargs):
+        super().__init__(model)
 
+    def get_explanations(self, x: torch.Tensor, label=None):  # pragma: no cover
+        raise NotImplementedError("EBP explainer is not implemented.")
 
-        label = self.model(x.float()).argmax(dim=-1) if label is None else label
-        attribution = excitation_backprop(
-            self.model,
-            x.float(),
-            label
-        )
-
-        return attribution
+    def get_layer_explanations(self, inputs: torch.Tensor, label=None):  # pragma: no cover
+        raise NotImplementedError("EBP explainer is not implemented.")

--- a/openbinn/explainers/catalog/feature_ablation/feature_ablation.py
+++ b/openbinn/explainers/catalog/feature_ablation/feature_ablation.py
@@ -1,97 +1,17 @@
+"""Placeholder for the unused Feature Ablation explainer."""
+
 import torch
 from ...api import BaseExplainer
-from captum.attr import FeatureAblation as FA_Captum
-from captum.attr import LayerFeatureAblation
+
 
 class FeatureAblation(BaseExplainer):
-    """
-    Provides feature ablation attributions.
-    Uses a perturbation-based approach to measure the change in output
-    when replacing parts of the input/layer with a baseline reference.
-    """
+    """Empty implementation for Feature Ablation explanations."""
 
-    def __init__(self, model, baseline=None, classification_type="multiclass") -> None:
-        """
-        Args:
-            model (torch.nn.Module): Model on which to make predictions.
-            baseline (torch.Tensor, optional): Baseline input for attribution calculation.
-            classification_type (str): Type of classification model ('multiclass' or 'binary').
-        """
-        self.baseline = baseline
-        self.classification_type = classification_type
-        super(FeatureAblation, self).__init__(model)
+    def __init__(self, model, *args, **kwargs):
+        super().__init__(model)
 
-    def get_explanations(self, x: torch.Tensor, label=None):
-        """
-        Explain an instance prediction using Feature Ablation.
-        """
-        self.model.eval()
-        self.model.zero_grad()
+    def get_explanations(self, x: torch.Tensor, label=None):  # pragma: no cover
+        raise NotImplementedError("FeatureAblation explainer is not implemented.")
 
-        # Define label if not provided
-        if label is None:
-            if self.classification_type == "binary":
-                label = (self.model(x.float()) > 0.5).long().view(-1)
-            else:
-                label = self.model(x.float()).argmax(dim=-1)
-        label = label.view(-1)
-
-        # Handle baseline: if None, automatically create one matching x; otherwise, check shape.
-        if self.baseline is None:
-            self.baseline = torch.zeros_like(x, device=x.device)
-        elif self.baseline.shape != x.shape:
-            raise ValueError(
-                f"Baseline shape {self.baseline.shape} does not match input shape {x.shape}."
-            )
-
-        # Compute attributions using Feature Ablation
-        ablator = FA_Captum(self.model)
-        attribution = ablator.attribute(
-            x.float(), 
-            target=label, 
-            layer_baselines=self.baseline
-        )
-
-        return attribution
-
-    def get_layer_explanations(self, inputs, label=None):
-        """
-        Returns layer-specific explanations using Feature Ablation.
-        Args:
-            inputs (torch.Tensor): Input tensor to the model.
-            label (torch.Tensor, optional): Label for which the explanation is calculated.
-        Returns:
-            explanations (dict): Dictionary containing attributions for each layer.
-        """
-        target_layer = self.model.print_layer
-
-        explanations = {}
-        self.model.eval()
-        self.model.zero_grad()
-
-        # Define label if not provided
-        label = torch.zeros_like(label)
-        label = label.view(-1)
-        label = label.long()
-
-
-        # Iterate through model layers and compute layer-specific attributions.
-        for name, layer in self.model.named_modules():
-            # Skip non-learnable layers (e.g., activations, dropout, etc.)
-            if not hasattr(layer, 'weight') and not hasattr(layer, 'bias'):
-                continue
-            elif 'intermediate' in name:
-                continue
-            elif target_layer < 7 and 'network' in name and int(name.split('.')[-2]) >= target_layer:
-                print(target_layer, name)
-                continue
-
-            # Initialize LayerFeatureAblation for the current layer.
-            layer_ablator = LayerFeatureAblation(self.model, layer)
-            attribution = layer_ablator.attribute(
-                inputs.float(),
-                target=label
-            )
-            explanations[name] = attribution
-
-        return explanations
+    def get_layer_explanations(self, inputs: torch.Tensor, label=None):  # pragma: no cover
+        raise NotImplementedError("FeatureAblation explainer is not implemented.")

--- a/openbinn/explainers/catalog/grad/grad.py
+++ b/openbinn/explainers/catalog/grad/grad.py
@@ -1,89 +1,17 @@
+"""Placeholder for the unused Gradient explainer."""
+
 import torch
-from captum.attr import Saliency as Gradient_Captum
 from ...api import BaseExplainer
 
 
 class Gradient(BaseExplainer):
-    """
-    A baseline approach for computing input attribution.
-    It returns the gradients with respect to inputs.
-    https://arxiv.org/pdf/1312.6034.pdf
-    """
+    """Empty implementation for plain gradient explanations."""
 
-    def __init__(self, model, absolute_value: bool = False) -> None:
-        """
-        Args:
-            model (torch.nn.Module): model on which to make predictions
-        """
-        self.abs = absolute_value
+    def __init__(self, model, *args, **kwargs):
+        super().__init__(model)
 
-        super(Gradient, self).__init__(model)
+    def get_explanations(self, x: torch.Tensor, label=None):  # pragma: no cover
+        raise NotImplementedError("Gradient explainer is not implemented.")
 
-    def get_explanations(self, x: torch.Tensor, label=None) -> torch:
-        """
-        Explain an instance prediction.
-        Args:
-            x (torch.Tensor, [N x 1 x d] for tabular instance; [N x m x n x d] for image instance): feature tensor
-            label (torch.Tensor, [N x ...]): labels to explain
-            abs (bool): Returns absolute value of gradients if set to True, otherwise returns the (signed) gradients if False
-        Returns:
-            exp (torch.Tensor, [N x 1 x d] for tabular instance; [N x m x n x d] for image instance: instance level explanation):
-        """
-        self.model.eval()
-        self.model.zero_grad()
-        label = self.model(x.float()).argmax(dim=-1) if label is None else label
-
-        saliency = Gradient_Captum(self.model)
-
-        attribution = saliency.attribute(x.float(), target=label, abs=self.abs)
-
-        return attribution
-
-    def get_layer_explanations(self, inputs, label=None):
-        '''
-        Returns explanations for each layer in the model
-        :param inputs: Input tensor to the model
-        :param label: Label for which the explanation is calculated (optional)
-        :return: Dictionary containing explanations for each layer
-        '''
-        explanations = {}
-        current_input = inputs.clone().detach()
-
-        for name, layer in self.model.named_children():
-            if isinstance(layer, torch.nn.ModuleList):
-                # Handle ModuleList explicitly
-                for i, sub_layer in enumerate(layer):
-                    current_output = sub_layer(current_input)
-
-                    # Calculate gradients for the current sub-layer's output
-                    saliency = Gradient_Captum(sub_layer)
-                    layer_label = current_output.argmax(dim=-1) if label is None else label
-
-                    layer_attribution = saliency.attribute(
-                        current_input.float(),
-                        target=layer_label,
-                        abs=self.abs
-                    )
-
-                    # Store the explanation in the dictionary
-                    explanations[f"{name}[{i}]"] = torch.FloatTensor(layer_attribution)
-                    current_input = current_output
-            else:
-                # Handle standard layers
-                current_output = layer(current_input)
-
-                # Calculate gradients for the current layer's output
-                saliency = Gradient_Captum(layer)
-                layer_label = current_output.argmax(dim=-1) if label is None else label
-
-                layer_attribution = saliency.attribute(
-                    current_input.float(),
-                    target=layer_label,
-                    abs=self.abs
-                )
-
-                # Store the explanation in the dictionary
-                explanations[name] = torch.FloatTensor(layer_attribution)
-                current_input = current_output
-
-        return explanations
+    def get_layer_explanations(self, inputs: torch.Tensor, label=None):  # pragma: no cover
+        raise NotImplementedError("Gradient explainer is not implemented.")

--- a/openbinn/explainers/catalog/input_x_gradient/input_x_gradient.py
+++ b/openbinn/explainers/catalog/input_x_gradient/input_x_gradient.py
@@ -1,76 +1,17 @@
+"""Placeholder for the unused Input×Gradient explainer."""
+
 import torch
 from ...api import BaseExplainer
-from captum.attr import InputXGradient as InputXGradient_Captum
-from captum.attr import LayerGradientXActivation as LayerGXA
 
 
 class InputTimesGradient(BaseExplainer):
-    """
-    A baseline approach for computing the attribution.
-    It multiplies input with the gradient with respect to input.
-    https://arxiv.org/abs/1605.01713
-    """
+    """Empty implementation for Input×Gradient explanations."""
 
-    def __init__(self, model):
-        """
-        Args:
-            model (torch.nn.Module): model on which to make predictions
-        """
-        super(InputTimesGradient, self).__init__(model)
+    def __init__(self, model, *args, **kwargs):
+        super().__init__(model)
 
-    def get_explanations(self, x: torch.Tensor, label=None):
-        """
-        Explain an instance prediction.
-        Args:
-            x (torch.Tensor, [N x 1 x d] for tabular instance; [N x m x n x d] for image instance): feature tensor
-            label (torch.Tensor, [N x ...]): labels to explain
-        Returns:
-            exp (torch.Tensor, [N x 1 x d] for tabular instance; [N x m x n x d] for image instance: instance level explanation):
-        """
-        self.model.eval()
-        self.model.zero_grad()
-        label = self.model(x.float()).argmax(dim=-1) if label is None else label
+    def get_explanations(self, x: torch.Tensor, label=None):  # pragma: no cover
+        raise NotImplementedError("InputTimesGradient explainer is not implemented.")
 
-        input_x_gradient = InputXGradient_Captum(self.model)
-
-        attribution = input_x_gradient.attribute(x.float(), target=label)
-
-        return attribution
-
-    def get_layer_explanations(self, inputs, label=None):
-        """
-        Returns explanations for each layer in the model using Layer Gradient X Activation.
-        Args:
-            inputs (torch.Tensor): Input tensor to the model
-            label (torch.Tensor): Label for which the explanation is calculated (optional)
-        Returns:
-            explanations (dict): Dictionary containing explanations for each layer
-        """
-        explanations = {}
-        self.model.eval()
-        self.model.zero_grad()
-
-        # Define label if not provided
-        if label is None:
-            label = self.model(inputs.float()).argmax(dim=-1)
-
-        # Iterate through the model layers
-        for name, layer in self.model.named_modules():
-            # Skip non-learnable layers (like nn.ReLU, nn.Dropout, etc.)
-            if not hasattr(layer, 'weight') and not hasattr(layer, 'bias'):
-                continue
-
-            # Initialize LayerGradientXActivation for the current layer
-            layer_gxa = LayerGXA(self.model, layer)
-
-            # Compute attributions for the current layer
-            attribution = layer_gxa.attribute(
-                inputs.float(),
-                target=label,
-                attribute_to_layer_input=False  # Set to True if needed
-            )
-
-            # Store the explanation for the current layer
-            explanations[name] = attribution
-
-        return explanations
+    def get_layer_explanations(self, inputs: torch.Tensor, label=None):  # pragma: no cover
+        raise NotImplementedError("InputTimesGradient explainer is not implemented.")

--- a/openbinn/explainers/catalog/integrated_gradients/integrated_gradients.py
+++ b/openbinn/explainers/catalog/integrated_gradients/integrated_gradients.py
@@ -1,98 +1,17 @@
+"""Placeholder for the unused Integrated Gradients explainer."""
+
 import torch
 from ...api import BaseExplainer
-from captum.attr import IntegratedGradients as IG_Captum
-from captum.attr import LayerIntegratedGradients as LayerIG
+
 
 class IntegratedGradients(BaseExplainer):
-    """
-    Provides integrated gradient attributions.
-    Original paper: https://arxiv.org/abs/1703.01365
-    """
+    """Empty implementation for Integrated Gradients."""
 
-    def __init__(self, model, method: str = 'gausslegendre', multiply_by_inputs: bool = False, baseline=None, classification_type="multiclass") -> None:
-        """
-        Args:
-            model (torch.nn.Module): model on which to make predictions
-            method (str): Integration method to use (e.g., 'gausslegendre')
-            multiply_by_inputs (bool): Whether to multiply the attributions by the inputs
-            baseline (torch.Tensor, optional): Baseline input for attribution calculation
-            classification_type (str): Type of classification model ('multiclass' or 'binary')
-        """
-        self.method = method
-        self.multiply_by_inputs = multiply_by_inputs
-        self.baseline = baseline
-        self.classification_type = classification_type
+    def __init__(self, model, *args, **kwargs):
+        super().__init__(model)
 
-        super(IntegratedGradients, self).__init__(model)
+    def get_explanations(self, x: torch.Tensor, label=None):  # pragma: no cover
+        raise NotImplementedError("IntegratedGradients explainer is not implemented.")
 
-    def get_explanations(self, x: torch.Tensor, label=None):
-        """
-        Explain an instance prediction.
-        """
-        self.model.eval()
-        self.model.zero_grad()
-
-        # Define label if not provided
-        if label is None:
-            if self.classification_type == "binary":
-                label = (self.model(x.float()) > 0.5).long().view(-1)
-            else:
-                label = self.model(x.float()).argmax(dim=-1)
-        label = label.view(-1)
-
-        # Handle baseline: if None, automatically create one matching x; otherwise, check shape.
-        if self.baseline is None:
-            self.baseline = torch.zeros_like(x, device=x.device)
-        elif self.baseline.shape != x.shape:
-            raise ValueError(
-                f"Baseline shape {self.baseline.shape} does not match input shape {x.shape}."
-            )
-
-        # Compute attributions using Integrated Gradients
-        ig = IG_Captum(self.model, self.multiply_by_inputs)
-        attribution = ig.attribute(
-            x.float(), target=label, method=self.method, baselines=self.baseline
-        )
-
-        return attribution
-
-    def get_layer_explanations(self, inputs, label=None):
-        """
-        Returns explanations for each layer in the model.
-        Args:
-            inputs (torch.Tensor): Input tensor to the model.
-            label (torch.Tensor, optional): Label for which the explanation is calculated.
-        Returns:
-            explanations (dict): Dictionary containing explanations for each layer.
-        """
-        target_layer = self.model.print_layer
-
-        explanations = {}
-        self.model.eval()
-        self.model.zero_grad()
-
-        # Define label if not provided
-        label = torch.zeros_like(label)
-        label = label.view(-1)
-        label = label.long()
-
-        # Iterate through model layers and compute layer-specific attributions
-        for name, layer in self.model.named_modules():
-            # Skip non-learnable layers (e.g., activation functions, dropout, etc.)
-            if not hasattr(layer, 'weight') and not hasattr(layer, 'bias'):
-                continue
-            elif 'intermediate' in name:
-                continue
-            elif target_layer < 7 and 'network' in name and int(name.split('.')[-2]) >= target_layer:
-                print(target_layer, name)
-                continue
-
-            # Initialize LayerIntegratedGradients for the current layer
-            layer_ig = LayerIG(self.model, layer)
-            attribution = layer_ig.attribute(
-                inputs.float(),
-                target=label,
-            )
-            explanations[name] = attribution
-
-        return explanations
+    def get_layer_explanations(self, inputs: torch.Tensor, label=None):  # pragma: no cover
+        raise NotImplementedError("IntegratedGradients explainer is not implemented.")

--- a/openbinn/explainers/catalog/lime/lime.py
+++ b/openbinn/explainers/catalog/lime/lime.py
@@ -1,150 +1,17 @@
-import numpy as np
+"""Placeholder for the unused LIME explainer."""
+
 import torch
 from ...api import BaseExplainer
-from openbinn.experiment_utils import convert_to_numpy
 
-# import lime
-from .lime_package import lime_tabular
-from .lime_package import lime_image
 
 class LIME(BaseExplainer):
-    """
-    This class gets explanations using LIME.
+    """Empty implementation for LIME explanations."""
 
-    model : original model (torch.nn.Module)
-    data : training data as torch.FloatTensor
-    mode : str, "tabular" or "images"
-    """
+    def __init__(self, model, *args, **kwargs):
+        super().__init__(model)
 
-    def __init__(self, model, data: torch.FloatTensor, std: float = 0.1,
-                 n_samples: int = 1000, kernel_width: float = 0.75,
-                 sample_around_instance: bool = True, mode: str = "tabular",
-                 discretize_continuous: bool = False, seed=None) -> None:
-        
-        self.output_dim = 2
-        # 데이터를 numpy array로 변환 후, 2D가 아닐 경우 2D로 평탄화
-        data_np = data.numpy()
-        if data_np.ndim > 2:
-            # 원래의 shape 저장 (예: (num_genes, num_features))
-            self.original_shape = data_np.shape[1:]
-            # 각 샘플을 평탄화하여 2D 형태로 변환
-            data_np = data_np.reshape(data_np.shape[0], -1)
-        else:
-            self.original_shape = None
-        self.data = data_np
-        self.mode = mode
-        # 모델과 predict 함수 설정
-        self.model_module = model
-        self.predict_function = model.predict
-        self.n_samples = n_samples
-        self.discretize_continuous = discretize_continuous
-        self.sample_around_instance = sample_around_instance
-        self.seed = seed
+    def get_explanations(self, x: torch.Tensor, label=None):  # pragma: no cover
+        raise NotImplementedError("LIME explainer is not implemented.")
 
-        # Tabular mode인 경우, numpy 배열을 입력받는 새로운 predict 함수 정의
-        if self.mode == "tabular":
-            def predict_np(x):
-                x_tensor = torch.FloatTensor(x)
-                with torch.no_grad():
-                    out = self.predict_function(x_tensor)
-                return out.detach().numpy()
-            self.predict_function_np = predict_np
-            self.explainer = lime_tabular.LimeTabularExplainer(
-                self.data,
-                mode="classification",
-                sample_around_instance=self.sample_around_instance,
-                discretize_continuous=self.discretize_continuous,
-                # 평탄화된 데이터의 feature 수를 기반으로 kernel_width 설정
-                kernel_width=kernel_width * np.sqrt(self.data.shape[1]),
-                std=std
-            )
-        else:
-            self.predict_function_np = self.predict_function  # for image mode
-            self.explainer = lime_image.LimeImageExplainer()
-
-        super(LIME, self).__init__(self.predict_function_np)
-
-    def get_explanations(self, x: torch.FloatTensor, label=None) -> torch.FloatTensor:
-        if label is None:
-            label = self.predict_function_np(x.float().numpy()).argmax(axis=-1)
-        else:
-            label = convert_to_numpy(label)
-        label = np.repeat(label, x.shape[0]) if label.shape == () else label
-
-        if self.seed is not None:
-            torch.manual_seed(self.seed)
-            np.random.seed(self.seed)
-        if self.mode == "tabular":
-            x_np = x.numpy()
-            if x_np.ndim > 2:
-                x_np = x_np.reshape(x_np.shape[0], -1)
-            num_features = x_np.shape[1]
-            attribution_scores = np.zeros(x_np.shape)
-            for i in range(x_np.shape[0]):
-                exp = self.explainer.explain_instance(x_np[i, :], self.predict_function_np,
-                                                      num_samples=self.n_samples,
-                                                      num_features=num_features)
-                for feature_idx, feature_attribution in exp.local_exp[1]:
-                    attribution_scores[i, feature_idx] = feature_attribution * (2 * label[i] - 1)
-            return torch.FloatTensor(attribution_scores)
-        else:
-            attribution_scores = []
-            for i in range(x.shape[0]):
-                exp = self.explainer.explain_instance(x,
-                                                      self.predict_function_np,
-                                                      top_labels=5,
-                                                      hide_color=0,
-                                                      num_samples=self.n_samples)
-                attribution_scores.append(exp)
-            return torch.FloatTensor(attribution_scores)
-
-    def get_layer_explanations(self, inputs, label=None):
-        """
-        Returns explanations for each layer in the model (tabular mode only).
-        """
-        explanations = {}
-        current_input = inputs.clone().detach()
-
-        for name, layer in self.model_module.named_children():
-            if self.mode != "tabular":
-                raise NotImplementedError("get_layer_explanations is only implemented for tabular mode.")
-
-            # Forward pass through the current layer.
-            current_output = layer(current_input)
-            
-            # 보존: 원래의 shape 확인 (batch, d1, d2) 또는 2D인 경우 그대로 사용
-            x_np = current_input.numpy()
-            if x_np.ndim > 2:
-                original_shape = x_np.shape[1:]  # 예: (num_genes, num_features)
-                x_np_flat = x_np.reshape(x_np.shape[0], -1)
-            else:
-                original_shape = None
-                x_np_flat = x_np
-
-            flat_feature_dim = x_np_flat.shape[1]
-            attribution_scores = np.zeros((x_np_flat.shape[0], flat_feature_dim))
-            
-            for i in range(x_np_flat.shape[0]):
-                exp = self.explainer.explain_instance(
-                    x_np_flat[i, :], 
-                    self.predict_function_np,
-                    num_samples=self.n_samples,
-                    num_features=flat_feature_dim
-                )
-                # LIME returns local_exp as a dict; 여기서는 클래스 1의 결과를 사용 (예제와 동일)
-                for feature_idx, feature_attribution in exp.local_exp[1]:
-                    # feature_idx가 flat_feature_dim 범위를 벗어나지 않는지 확인
-                    if feature_idx < flat_feature_dim:
-                        # label이 주어졌으면 해당 값을 사용, 아니면 기본값 1
-                        mult = (2 * (label[i] if label is not None else 1) - 1)
-                        attribution_scores[i, feature_idx] = feature_attribution * mult
-
-            # 원래의 shape으로 재구성
-            if original_shape is not None:
-                attribution_scores = attribution_scores.reshape(x_np.shape[0], *original_shape)
-            
-            explanations[name] = torch.FloatTensor(attribution_scores)
-            # 다음 레이어를 위해 current_input 업데이트
-            current_input = current_output
-
-        return explanations
+    def get_layer_explanations(self, inputs: torch.Tensor, label=None):  # pragma: no cover
+        raise NotImplementedError("LIME explainer is not implemented.")

--- a/openbinn/explainers/catalog/lrp/lrp_captum.py
+++ b/openbinn/explainers/catalog/lrp/lrp_captum.py
@@ -1,78 +1,17 @@
+"""Placeholder for the unused LRP explainer."""
+
 import torch
 from ...api import BaseExplainer
-from captum.attr import LRP as LRP_Captum
-from captum.attr import LayerLRP as LayerLRP
+
 
 class LRP(BaseExplainer):
-    """
-    Provides Layer-wise Relevance Propagation (LRP) attributions.
-    """
+    """Empty implementation for Layer-wise Relevance Propagation."""
 
-    def __init__(self, model) -> None:
-        """
-        Args:
-            model (torch.nn.Module): model on which to make predictions
-        """
-        super(LRP, self).__init__(model)
+    def __init__(self, model, *args, **kwargs):
+        super().__init__(model)
 
-    def get_explanations(self, x: torch.Tensor, label=None):
-        """
-        Explain an instance prediction using LRP.
-        Args:
-            x (torch.Tensor): Input tensor to the model
-            label (torch.Tensor): Target label for which the explanation is calculated (optional)
-        Returns:
-            torch.Tensor: LRP attributions
-        """
-        self.model.eval()
-        self.model.zero_grad()
+    def get_explanations(self, x: torch.Tensor, label=None):  # pragma: no cover
+        raise NotImplementedError("LRP explainer is not implemented.")
 
-        # Define label if not provided
-        label = self.model(x.float()).argmax(dim=-1) if label is None else label
-        label = label.view(-1)  # Flatten label if necessary
-
-        # Compute attributions using LRP
-        lrp = LRP_Captum(self.model)
-        attribution = lrp.attribute(
-            x.float(), target=label
-        )
-
-        return attribution
-
-    def get_layer_explanations(self, inputs, label=None):
-        """
-        Returns explanations for each layer in the model using Layer LRP.
-        Args:
-            inputs (torch.Tensor): Input tensor to the model
-            label (torch.Tensor): Label for which the explanation is calculated (optional)
-        Returns:
-            explanations (dict): Dictionary containing explanations for each layer
-        """
-        explanations = {}
-        self.model.eval()
-        self.model.zero_grad()
-
-        # Define label if not provided
-        if label is None:
-            label = self.model(inputs.float()).argmax(dim=-1)
-
-        # Iterate through the model layers
-        for name, layer in self.model.named_modules():
-            # Skip non-learnable layers (like nn.ReLU, nn.Dropout, etc.)
-            if not hasattr(layer, 'weight') and not hasattr(layer, 'bias'):
-                continue
-
-            # Initialize LayerLRP for the current layer
-            layer_lrp = LayerLRP(self.model, layer)
-
-            # Compute attributions for the current layer
-            attribution = layer_lrp.attribute(
-                inputs.float(),
-                target=label,
-                attribute_to_layer_input=False  # Set to True if needed
-            )
-
-            # Store the explanation for the current layer
-            explanations[name] = attribution
-
-        return explanations
+    def get_layer_explanations(self, inputs: torch.Tensor, label=None):  # pragma: no cover
+        raise NotImplementedError("LRP explainer is not implemented.")

--- a/openbinn/explainers/catalog/random_baseline/random_baseline.py
+++ b/openbinn/explainers/catalog/random_baseline/random_baseline.py
@@ -1,34 +1,17 @@
+"""Placeholder for the unused random baseline explainer."""
+
 import torch
 from ...api import BaseExplainer
 
 
 class RandomBaseline(BaseExplainer):
-    """
-    A control baseline that returns a random explanation sampled independently of the 
-    input and predictive model.
-    """
+    """Empty implementation for random baseline explanations."""
 
-    def __init__(self, model, seed=None) -> None:
-        """
-        Args:
-            model (torch.nn.Module): model on which to make predictions
-        """
-        self.seed = seed
+    def __init__(self, model, *args, **kwargs):
+        super().__init__(model)
 
-        super(RandomBaseline, self).__init__(model)
+    def get_explanations(self, x: torch.Tensor, label=None):  # pragma: no cover
+        raise NotImplementedError("RandomBaseline explainer is not implemented.")
 
-    def get_explanations(self, x: torch.Tensor, label=None) -> torch.tensor:
-        """
-        Returns a random standard normal vector of shape x.shape.
-        
-        Args:
-            x (torch.Tensor, [N x 1 x d] for tabular instance; [N x m x n x d] for image instance): feature tensor
-            label (torch.Tensor, [N x ...]): labels to explain
-        Returns:
-            exp (torch.Tensor, [N x 1 x d] for tabular instance; [N x m x n x d] for image instance: instance level explanation):
-        """
-        if self.seed is not None:
-            torch.manual_seed(self.seed)
-        attribution = torch.randn(size=x.shape)
-
-        return attribution
+    def get_layer_explanations(self, inputs: torch.Tensor, label=None):  # pragma: no cover
+        raise NotImplementedError("RandomBaseline explainer is not implemented.")

--- a/openbinn/explainers/catalog/shap_explainer/shap_explainer.py
+++ b/openbinn/explainers/catalog/shap_explainer/shap_explainer.py
@@ -1,51 +1,17 @@
-import xgboost
-import shap
+"""Placeholder for the unused SHAP explainer."""
+
 import torch
-import numpy as np
-from torch import nn
-from torch.nn import functional as F
 from ...api import BaseExplainer
-from shap import KernelExplainer
-from shap import DeepExplainer
+
 
 class SHAPExplainer(BaseExplainer):
-    
-    '''
-    param: model: model object
-    param: data: pandas data frame or numpy array
-    param: link: str, 'identity' or 'logit'
-    param: feature_perturbation: str, 'tree_path_dependent' or 'interventional'
-    '''
-    
-    def __init__(self, model, data: torch.FloatTensor, domain: str = 'non_deep', link: str = 'identity',
-                 function_class: str = 'non_tree', feature_perturbation: str = 'interventional'):
+    """Empty implementation for SHAP explanations."""
+
+    def __init__(self, model, *args, **kwargs):
         super().__init__(model)
-        self.data = data.numpy()
-        self.domain = domain
-        if self.domain == 'non_deep':
-            if function_class == 'non_tree':
-                self.explainer = shap.KernelExplainer(self.model, self.data, link=link)
-            else:
-                self.explainer = shap.TreeExplainer(self.model, self.data, model_output='raw',
-                                           feature_perturbation=feature_perturbation)
-        elif self.domain == 'deep':
-            self.explainer = shap.DeepExplainer(self.model[0], self.data)
 
-    def get_explanations(self, x: torch.FloatTensor, label=None):
-        '''
-        Returns SHAP values as the explaination of the decision made for the input data (data_x)
-        :param x: data samples to explain decision for
-        :return: SHAP values [dim (shap_vals) == dim (x)]
-        '''
-        
-        x = x.numpy()
-        
-        if self.domain == 'non_deep':
-            # we are explaining the the prob of 1; choosing [0] would explain P(y=0|x)
-            shap_vals = self.explainer.shap_values(x)[1]
-        elif self.domain == 'deep':
-            shap_vals = self.explainer.shap_values(x)
-        return torch.FloatTensor(shap_vals)
+    def get_explanations(self, x: torch.Tensor, label=None):  # pragma: no cover
+        raise NotImplementedError("SHAP explainer is not implemented.")
 
-
-
+    def get_layer_explanations(self, inputs: torch.Tensor, label=None):  # pragma: no cover
+        raise NotImplementedError("SHAP explainer is not implemented.")

--- a/openbinn/explainers/catalog/shap_explainer/shap_explainer_captum.py
+++ b/openbinn/explainers/catalog/shap_explainer/shap_explainer_captum.py
@@ -1,109 +1,17 @@
+"""Placeholder for the unused DeepLiftShap explainer."""
+
 import torch
 from ...api import BaseExplainer
-from captum.attr import DeepLiftShap, LayerDeepLiftShap
+
 
 class DeepLiftShapExplainer(BaseExplainer):
-    """
-    Provides DeepLiftShap attributions.
-    Uses DeepLiftShap for input-level explanations and LayerDeepLiftShap for layer-wise explanations.
-    Based on:
-    https://papers.nips.cc/paper/7062-a-unified-approach-to-interpreting-model-predictions.pdf
-    """
+    """Empty implementation for DeepLiftShap explanations."""
 
-    def __init__(self, model, multiply_by_inputs: bool = True, baseline=None, classification_type="binary") -> None:
-        """
-        Args:
-            model (torch.nn.Module): model on which to make predictions.
-            multiply_by_inputs (bool): Whether to multiply the attributions by the inputs.
-            baseline (torch.Tensor, optional): Baseline input for attribution calculation.
-            classification_type (str): 'multiclass' or 'binary'.
-        """
-        self.multiply_by_inputs = multiply_by_inputs
-        self.baseline = baseline
-        self.classification_type = classification_type
-        super(DeepLiftShapExplainer, self).__init__(model)
+    def __init__(self, model, *args, **kwargs):
+        super().__init__(model)
 
-    def get_explanations(self, x: torch.Tensor, label=None):
-        """
-        Compute DeepLiftShap explanations for the given input.
-        Args:
-            x (torch.Tensor): Input tensor.
-            label (torch.Tensor, optional): Target label for which attributions are computed.
-        Returns:
-            torch.Tensor: Attributions with the same shape as x.
-        """
-        self.model.eval()
-        self.model.zero_grad()
+    def get_explanations(self, x: torch.Tensor, label=None):  # pragma: no cover
+        raise NotImplementedError("DeepLiftShap explainer is not implemented.")
 
-        # Compute label if not provided, then flatten and cast to long.
-        if label is None:
-            if self.classification_type == "binary":
-                label = (self.model(x.float()) > 0.5).long().view(-1)
-            else:
-                label = self.model(x.float()).argmax(dim=-1)
-        label = label.view(-1).long()
-
-        # Handle baseline: create one matching x if not provided.
-        if self.baseline is None:
-            self.baseline = torch.zeros_like(x, device=x.device)
-        elif self.baseline.shape != x.shape:
-            raise ValueError(
-                f"Baseline shape {self.baseline.shape} does not match input shape {x.shape}."
-            )
-
-        # Compute attributions using DeepLiftShap.
-        dls = DeepLiftShap(self.model, multiply_by_inputs=self.multiply_by_inputs)
-        attributions = dls.attribute(x.float(), baselines=self.baseline, target=label)
-        return attributions
-
-    def get_layer_explanations(self, inputs, label=None):
-        """
-        Compute layer-wise DeepLiftShap explanations.
-        Args:
-            inputs (torch.Tensor): Input tensor to the model.
-            label (torch.Tensor, optional): Target label for which attributions are computed.
-        Returns:
-            dict: Dictionary mapping layer names to their respective attributions.
-        """
-        explanations = {}
-        self.model.eval()
-        self.model.zero_grad()
-        inputs = inputs.clone().detach().requires_grad_(True)
-
-        # 이진 분류이며 모델 출력이 단일 스칼라인 경우 target은 항상 0으로 설정
-        if self.classification_type == "binary":
-            label = torch.zeros(inputs.shape[0], device=inputs.device).long()
-        else:
-            if label is None:
-                label = self.model(inputs.float()).argmax(dim=-1)
-            else:
-                label = label.view(-1)
-            label = label.long()
-
-        # Iterate through model layers.
-        for name, layer in self.model.named_modules():
-            # Skip non-learnable layers (예: activation, dropout 등)
-            if not hasattr(layer, "weight") and not hasattr(layer, "bias"):
-                continue
-
-            # Initialize LayerDeepLiftShap for the current layer.
-            layer_dls = LayerDeepLiftShap(self.model, layer, multiply_by_inputs=self.multiply_by_inputs)
-            # Compute attributions for the current layer.
-            # attribute_to_layer_input: True면 레이어 입력에 대한 기여도를, False면 출력에 대한 기여도를 계산합니다.
-            try:
-                attribution = layer_dls.attribute(
-                    inputs.float(),
-                    baselines=self.baseline,
-                    target=label,
-                    attribute_to_layer_input=False
-                )
-            except RuntimeError as e:
-                if "not have been used in the graph" in str(e):
-                    # 해당 레이어에서 미분 경로가 없으면, 0 텐서를 반환하도록 함.
-                    attribution = torch.zeros_like(inputs)
-                    print(f"Warning: Attribution for layer {name} not computed due to unused tensor error. Returning zeros.")
-                else:
-                    raise e
-            explanations[name] = attribution
-
-        return explanations
+    def get_layer_explanations(self, inputs: torch.Tensor, label=None):  # pragma: no cover
+        raise NotImplementedError("DeepLiftShap explainer is not implemented.")

--- a/openbinn/explainers/catalog/smoothgrad/smoothgrad.py
+++ b/openbinn/explainers/catalog/smoothgrad/smoothgrad.py
@@ -1,113 +1,17 @@
+"""Placeholder for the unused SmoothGrad explainer."""
+
 import torch
-import numpy as np
 from ...api import BaseExplainer
-from captum.attr import NoiseTunnel
-from captum.attr import Saliency
 
 
 class SmoothGrad(BaseExplainer):
-    """
-    Provides SmoothGrad attributions.
-    Original paper: https://arxiv.org/abs/1706.03825
-    Captum documentation: https://captum.ai/api/noise_tunnel.html
-    """
+    """Empty implementation for SmoothGrad explanations."""
 
-    def __init__(self, model, n_samples: int = 100, standard_deviation: float = 0.1, seed = None) -> None:
-        """
-        Args:
-            model (torch.nn.Module): model on which to make predictions
-        """
+    def __init__(self, model, *args, **kwargs):
+        super().__init__(model)
 
-        self.n_samples = n_samples
-        self.standard_deviation = standard_deviation
-        self.seed = seed
+    def get_explanations(self, x: torch.Tensor, label=None):  # pragma: no cover
+        raise NotImplementedError("SmoothGrad explainer is not implemented.")
 
-        super(SmoothGrad, self).__init__(model)
-
-    def get_explanations(self, x: torch.Tensor, label=None):
-        """
-        Explain an instance prediction.
-        Args:
-            x (torch.Tensor, [N x 1 x d] for tabular instance; [N x m x n x d] for image instance): feature tensor
-            label (torch.Tensor, [N x ...]): labels to explain
-        Returns:
-            exp (torch.Tensor, [N x 1 x d] for tabular instance; [N x m x n x d] for image instance: instance level explanation):
-        """
-        self.model.eval()
-        self.model.zero_grad()
-        label = self.model(x.float()).argmax(dim=-1) if label is None else label
-
-        if self.seed is not None:
-            torch.manual_seed(self.seed); np.random.seed(self.seed)
-
-        noise_tunnel = NoiseTunnel(Saliency(self.model))
-
-        attribution = noise_tunnel.attribute(x.float(),
-                                             nt_type='smoothgrad',
-                                             target=label,
-                                             nt_samples=self.n_samples,
-                                             stdevs=self.standard_deviation,
-                                             abs=False)
-
-        return attribution
-        
-    def get_layer_explanations(self, inputs, label=None):
-        '''
-        Returns explanations for each layer in the model
-        :param inputs: Input tensor to the model
-        :param label: Label for which the explanation is calculated (optional)
-        :return: Dictionary containing explanations for each layer
-        '''
-        explanations = {}
-        current_input = inputs.clone().detach()
-
-        for name, layer in self.model.named_children():
-            if isinstance(layer, torch.nn.ModuleList):
-                # Handle ModuleList explicitly
-                for i, sub_layer in enumerate(layer):
-                    current_output = sub_layer(current_input)
-
-                    # Calculate SmoothGrad attributions for the current sub-layer's output
-                    noise_tunnel = NoiseTunnel(Saliency(sub_layer))
-                    layer_label = current_output.argmax(dim=-1) if label is None else label
-
-                    if self.seed is not None:
-                        torch.manual_seed(self.seed); np.random.seed(self.seed)
-
-                    sub_layer_attribution = noise_tunnel.attribute(
-                        current_input.float(),
-                        nt_type='smoothgrad',
-                        target=layer_label,
-                        nt_samples=self.n_samples,
-                        stdevs=self.standard_deviation,
-                        abs=False
-                    )
-
-                    # Store explanation for the sub-layer
-                    explanations[f"{name}[{i}]"] = torch.FloatTensor(sub_layer_attribution)
-                    current_input = current_output
-            else:
-                # Handle standard layers
-                current_output = layer(current_input)
-
-                # Calculate SmoothGrad attributions for the current layer's output
-                noise_tunnel = NoiseTunnel(Saliency(layer))
-                layer_label = current_output.argmax(dim=-1) if label is None else label
-
-                if self.seed is not None:
-                    torch.manual_seed(self.seed); np.random.seed(self.seed)
-
-                layer_attribution = noise_tunnel.attribute(
-                    current_input.float(),
-                    nt_type='smoothgrad',
-                    target=layer_label,
-                    nt_samples=self.n_samples,
-                    stdevs=self.standard_deviation,
-                    abs=False
-                )
-
-                # Store the explanation in the dictionary
-                explanations[name] = torch.FloatTensor(layer_attribution)
-                current_input = current_output
-
-        return explanations
+    def get_layer_explanations(self, inputs: torch.Tensor, label=None):  # pragma: no cover
+        raise NotImplementedError("SmoothGrad explainer is not implemented.")


### PR DESCRIPTION
## Summary
- reduce maintenance overhead by replacing unused explainer implementations with placeholders
- leave DeepLift as the only explainer with layer-wise functionality

## Testing
- `python -m py_compile openbinn/explainers/catalog/ebp/ebp.py`
- `python -m py_compile openbinn/explainers/catalog/grad/grad.py`
- `python -m py_compile openbinn/explainers/catalog/input_x_gradient/input_x_gradient.py`
- `python -m py_compile openbinn/explainers/catalog/integrated_gradients/integrated_gradients.py`
- `python -m py_compile openbinn/explainers/catalog/lime/lime.py`
- `python -m py_compile openbinn/explainers/catalog/lrp/lrp_captum.py`
- `python -m py_compile openbinn/explainers/catalog/random_baseline/random_baseline.py`
- `python -m py_compile openbinn/explainers/catalog/shap_explainer/shap_explainer.py`
- `python -m py_compile openbinn/explainers/catalog/shap_explainer/shap_explainer_captum.py`
- `python -m py_compile openbinn/explainers/catalog/smoothgrad/smoothgrad.py`
- `python -m py_compile openbinn/explainers/catalog/feature_ablation/feature_ablation.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_6843f833361c8322af34e64c92328974