### PR TITLE
Add statistical method control and slurm pipeline

### DIFF
--- a/analysis/importance_calculation.py
+++ b/analysis/importance_calculation.py
@@ -178,18 +178,29 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--start_sim", type=int, default=1)
     ap.add_argument("--end_sim",   type=int, default=N_SIM)
+    ap.add_argument(
+        "--statistical_method",
+        choices=["bootstrap", "gene-permutation", "label-permutation", "all"],
+        default="all",
+        help="Variant type to process when computing importances.",
+    )
     args = ap.parse_args()
 
     reactome = load_reactome_once()
 
-    for i in range(args.start_sim, args.end_sim+1):
-        base = DATA_ROOT/f"{i}"
+    if args.statistical_method == "all":
+        variants = ["bootstrap", "gene-permutation", "label-permutation"]
+    else:
+        variants = [args.statistical_method]
+
+    for i in range(args.start_sim, args.end_sim + 1):
+        base = DATA_ROOT / f"{i}"
         print(f"\n■■ Simulation {i:3d} ■■")
         explain_dataset(base, reactome)  # original
 
-        for vtype in ["bootstrap","gene-permutation","label-permutation"]:
-            for b in range(1, N_VARIANTS+1):
-                vdir = base/vtype/f"{b}"
+        for vtype in variants:
+            for b in range(1, N_VARIANTS + 1):
+                vdir = base / vtype / f"{b}"
                 if vdir.exists():
                     print(f"  → {vtype}/{b}")
                     explain_dataset(vdir, reactome)

--- a/analysis/pvalue_calculation.py
+++ b/analysis/pvalue_calculation.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+pvalue_calculation.py
+---------------------
+Compute null distributions and p-values for BINN importance scores.
+The variant used to construct the null distribution is selected via
+``--statistical_method``.
+"""
+
+from pathlib import Path
+import argparse, warnings
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+# user settings
+METHOD = "deeplift"
+N_VARIANTS = 100
+DATA_ROOT = Path("./data/b0_g0.0")
+OUT_ROOT = Path("./results/b0_g0.0")
+sns.set(style="whitegrid")
+
+def process_sim(sim: int, variant: str):
+    sim_dir = DATA_ROOT / f"{sim}"
+    orig_fp = sim_dir / f"PNet_{METHOD}_target_scores.csv"
+    if not orig_fp.exists():
+        print(f"[skip] 원본 score 없음 → sim {sim}")
+        return
+
+    orig_df = pd.read_csv(orig_fp, index_col=0)
+
+    perm_dfs = []
+    for b in range(1, N_VARIANTS + 1):
+        fp = sim_dir / variant / f"{b}" / f"PNet_{METHOD}_target_scores.csv"
+        if fp.exists():
+            perm_dfs.append(pd.read_csv(fp, index_col=0))
+    if not perm_dfs:
+        print(f"[skip] {variant} 없음 → sim {sim}")
+        return
+
+    for b, df_b in enumerate(perm_dfs, start=1):
+        orig_df[f"null_{b}"] = df_b["importance"]
+
+    pathways_df = orig_df[orig_df["layer"] > 0]
+    df = pathways_df.reset_index().rename(columns={"index": "pathway_id"})
+    df["uid"] = df["pathway_id"] + "_L" + df["layer"].astype(int).astype(str)
+    df = df.set_index("uid")
+
+    null_cols = [c for c in df.columns if c.startswith("null_")]
+    null_list = [df.loc[r, null_cols].values.astype(float) for r in df.index]
+    obs_list = df["importance"].values
+    pathways = df.index.to_list()
+
+    x_min = min([d.min() for d in null_list] + list(obs_list))
+    x_max = max([d.max() for d in null_list] + list(obs_list))
+    margin = 0.05 * (x_max - x_min)
+    x_min -= margin
+    x_max += margin
+
+    fig, axes = plt.subplots(nrows=len(pathways), ncols=1,
+                             figsize=(10, 4 * len(pathways)), sharex=True)
+    for ax, pid, null_vals, obs in zip(axes, pathways, null_list, obs_list):
+        sns.histplot(null_vals, bins=50, stat="density", kde=True, ax=ax)
+        ax.axvline(obs, color="red", linestyle="--", label=f"Observed ({obs:.2f})")
+        ax.set_xlim(x_min, x_max)
+        ax.set_ylabel("Density")
+        ax.set_title(pid)
+        ax.legend(frameon=False)
+    axes[-1].set_xlabel("Importance")
+    plt.tight_layout()
+
+    out_dir = OUT_ROOT / variant
+    out_dir.mkdir(parents=True, exist_ok=True)
+    fig_fp = out_dir / f"sim_{sim}_distributions.png"
+    plt.savefig(fig_fp, dpi=300)
+    plt.close(fig)
+
+    p_vals = [np.mean(null >= obs) for null, obs in zip(null_list, obs_list)]
+    p_df = pd.DataFrame({"pathway": pathways, "p_value": p_vals})
+    csv_fp = out_dir / f"sim_{sim}_pvalues.csv"
+    p_df.to_csv(csv_fp, index=False)
+
+    print(f"{variant:<16} sim {sim:3d} │ saved → {fig_fp.name} , {csv_fp.name}")
+
+
+def main():
+    warnings.filterwarnings("ignore", category=UserWarning)
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--statistical_method",
+                    choices=["bootstrap", "gene-permutation", "label-permutation"],
+                    required=True,
+                    help="Variant type used for the null distribution")
+    ap.add_argument("--start_sim", type=int, default=1)
+    ap.add_argument("--end_sim", type=int, default=100)
+    args = ap.parse_args()
+
+    for i in range(args.start_sim, args.end_sim + 1):
+        process_sim(i, args.statistical_method)
+
+    print("\n✓ p-value 계산 완료.")
+
+if __name__ == "__main__":
+    main()

--- a/analysis/run_slurm_pipeline.sh
+++ b/analysis/run_slurm_pipeline.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Run training, importance calculation and p-value estimation using srun.
+# Usage: bash run_slurm_pipeline.sh --statistical_method gene-permutation --device gpu
+
+set -e
+
+STAT_METHOD="gene-permutation"
+DEVICE="gpu"
+START=1
+END=100
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --statistical_method)
+      STAT_METHOD="$2"; shift 2;;
+    --device)
+      DEVICE="$2"; shift 2;;
+    --start)
+      START="$2"; shift 2;;
+    --end)
+      END="$2"; shift 2;;
+    *) echo "Unknown option $1"; exit 1;;
+  esac
+done
+
+if [[ "$DEVICE" == "gpu" ]]; then
+  SRUN_PREFIX="srun --gres=gpu:A4000 -p gpu  --time=50:00:00"
+else
+  SRUN_PREFIX="srun  --time=50:00:00"
+fi
+
+for ((i=START;i<=END;i++)); do
+  echo "===== Simulation $i ($STAT_METHOD) ====="
+  start_time=$(date +%s)
+  $SRUN_PREFIX python train_simulations.py --start_sim $i --end_sim $i \
+      --statistical_method $STAT_METHOD
+  $SRUN_PREFIX python importance_calculation.py --start_sim $i --end_sim $i \
+      --statistical_method $STAT_METHOD
+  $SRUN_PREFIX python pvalue_calculation.py --start_sim $i --end_sim $i \
+      --statistical_method $STAT_METHOD
+  end_time=$(date +%s)
+  runtime=$((end_time-start_time))
+  echo "Simulation $i finished in ${runtime}s" 
+  echo
+done


### PR DESCRIPTION
## Summary
- allow training script to load pre-computed optimal hyperparameters
- support variant choice via `--statistical_method` for training and importance calculation
- unify permutation p-value computation into `pvalue_calculation.py`
- add slurm helper script to run training, explanation, and p-value steps sequentially

## Testing
- `python -m py_compile analysis/train_simulations.py analysis/importance_calculation.py analysis/pvalue_calculation.py`

------
https://chatgpt.com/codex/tasks/task_e_6843ff4b28388322a1de306ef1598637