### PR TITLE
Add start/end range options

### DIFF
--- a/analysis/generate_simulations.py
+++ b/analysis/generate_simulations.py
@@ -101,11 +101,20 @@ def main():
     ap = argparse.ArgumentParser(description="Generate simulation datasets")
     ap.add_argument("--beta", type=float, default=0)
     ap.add_argument("--gamma", type=float, default=0.0)
-    ap.add_argument("--n_sim", type=int, default=N_SIM)
+    ap.add_argument("--n_sim", type=int, default=N_SIM,
+                    help="Number of simulations if --end_sim is not given")
+    ap.add_argument("--start_sim", type=int, default=1,
+                    help="Start index of simulation (inclusive)")
+    ap.add_argument("--end_sim", type=int,
+                    help="End index of simulation (inclusive). Defaults to n_sim")
     args = ap.parse_args()
 
+    end = args.end_sim if args.end_sim is not None else args.n_sim
+    if end < args.start_sim:
+        raise ValueError("end_sim must be >= start_sim")
+
     data_root = Path(f"./data/b{args.beta}_g{args.gamma}")
-    for i in range(1, args.n_sim + 1):
+    for i in range(args.start_sim, end + 1):
         generate_single(data_root / f"{i}", args.beta, args.gamma, seed=42 + i)
     print(f"✓ generated simulations at {data_root}")
 

--- a/analysis/train_original.py
+++ b/analysis/train_original.py
@@ -223,6 +223,8 @@ def main():
     pl.seed_everything(42, workers=True)
 
     ap = argparse.ArgumentParser()
+    ap.add_argument("--start_sim", type=int, default=1)
+    ap.add_argument("--end_sim",   type=int, default=N_SIM)
     ap.add_argument("--beta", type=float, default=DEFAULT_BETA)
     ap.add_argument("--gamma", type=float, default=DEFAULT_GAMMA)
     args = ap.parse_args()
@@ -231,7 +233,7 @@ def main():
 
     reactome = load_reactome_once()
 
-    for i in range(1, N_SIM + 1):
+    for i in range(args.start_sim, args.end_sim + 1):
         base_dir = data_root / f"{i}"
         print(f"\n■■ Simulation {i:3d} ■■")
 


### PR DESCRIPTION
## Summary
- allow generating subsets of simulations by passing `--start_sim` and `--end_sim`
- train original datasets for a subset of indices via the same CLI options

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68442b2faa3483228b1a8596a7f1faf9