### PR TITLE
Update sim data generation with start/end options

### DIFF
--- a/analysis/generate_b4g4_simulations.py
+++ b/analysis/generate_b4g4_simulations.py
@@ -131,9 +131,9 @@ def make_label_perm(Xm, Xc, y, rng):
     yp = pd.Series(rng.permutation(y.values), index=y.index, name="response")
     return Xm, Xc, yp
 
-def main():
+def main(start_sim: int = 1, end_sim: int = N_SIM):
     print("▶ Generating simulations & variants …")
-    for i in range(1, N_SIM+1):
+    for i in range(start_sim, end_sim + 1):
         rng_sim = np.random.RandomState(RNG_BASE_SEED + i)
         S   = X_true.values @ alpha
         eta = (BETA*S + GAMMA*S**2) + DELTAS[0]*(BETA*S + GAMMA*S**2) \
@@ -188,7 +188,11 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Generate simulation datasets")
     parser.add_argument("--beta", type=float, default=BETA)
     parser.add_argument("--gamma", type=float, default=GAMMA)
+    parser.add_argument("--start_sim", type=int, default=1,
+                        help="Start index of simulation (inclusive)")
+    parser.add_argument("--end_sim", type=int, default=N_SIM,
+                        help="End index of simulation (inclusive)")
     args = parser.parse_args()
     BETA = args.beta
     GAMMA = args.gamma
-    main()
+    main(args.start_sim, args.end_sim)

--- a/analysis/run_slurm_parallel.sh
+++ b/analysis/run_slurm_parallel.sh
@@ -41,8 +41,10 @@ else
 fi
 
 # Generate data and train originals once to obtain optimal parameters
-$SRUN_PREFIX python generate_b4g4_simulations.py --beta "$BETA" --gamma "$GAMMA"
-$SRUN_PREFIX python train_original.py --beta "$BETA" --gamma "$GAMMA"
+$SRUN_PREFIX python generate_b4g4_simulations.py --beta "$BETA" --gamma "$GAMMA" \
+    --start_sim "$START" --end_sim "$END"
+$SRUN_PREFIX python train_original.py --beta "$BETA" --gamma "$GAMMA" \
+    --start_sim "$START" --end_sim "$END"
 
 
 total=$((END - START + 1))


### PR DESCRIPTION
## Summary
- add `start_sim`/`end_sim` arguments to `generate_b4g4_simulations.py`
- propagate these arguments to `run_slurm_parallel.sh`

## Testing
- `python -m py_compile analysis/generate_b4g4_simulations.py`

------
https://chatgpt.com/codex/tasks/task_e_68442e13ac888322b3ee96d6c55156f6