### PR TITLE
Activate conda env for each srun job

### DIFF
--- a/analysis/run_slurm_parallel.sh
+++ b/analysis/run_slurm_parallel.sh
@@ -6,6 +6,15 @@
 
 set -e
 
+# Activate the required conda environment for the launcher
+CONDA_BASE="$(conda info --base)"
+CONDA_INIT="${CONDA_BASE}/etc/profile.d/conda.sh"
+source "$CONDA_INIT"
+conda activate openBINN
+
+# Command to re-activate the environment inside each srun call
+CONDA_ACT_CMD="source $CONDA_INIT && conda activate openBINN"
+
 STAT_METHOD="gene-permutation"
 DEVICE="gpu"
 START=1
@@ -35,16 +44,14 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ "$DEVICE" == "gpu" ]]; then
-  SRUN_PREFIX="srun --gres=gpu:A4000 -p gpu --time=50:00:00"
+  SRUN_PREFIX="srun --gres=gpu:A4000 -p gpu --time=50:00:00 --export=ALL"
 else
-  SRUN_PREFIX="srun --time=50:00:00"
+  SRUN_PREFIX="srun --time=50:00:00 --export=ALL"
 fi
 
 # Generate data and train originals once to obtain optimal parameters
-$SRUN_PREFIX python sim_data_generation.py --beta "$BETA" --gamma "$GAMMA" \
-    --start_sim "$START" --end_sim "$END"
-$SRUN_PREFIX python train_original.py --beta "$BETA" --gamma "$GAMMA" \
-    --start_sim "$START" --end_sim "$END"
+$SRUN_PREFIX bash -c "$CONDA_ACT_CMD && python sim_data_generation.py --beta $BETA --gamma $GAMMA --start_sim $START --end_sim $END"
+$SRUN_PREFIX bash -c "$CONDA_ACT_CMD && python train_original.py --beta $BETA --gamma $GAMMA --start_sim $START --end_sim $END"
 
 total=$((END - START + 1))
 chunk=$(( (total + PARALLEL - 1) / PARALLEL ))
@@ -55,10 +62,10 @@ for ((i=0; i<PARALLEL; i++)); do
   if (( beg > END )); then break; fi
   if (( end > END )); then end=$END; fi
   echo "==== Launching simulations ${beg}-${end} ===="
-  $SRUN_PREFIX python permutation_analysis.py \
-    --statistical_method "$STAT_METHOD" \
-    --start_sim "$beg" --end_sim "$end" \
-    --beta "$BETA" --gamma "$GAMMA" &
+  $SRUN_PREFIX bash -c "$CONDA_ACT_CMD && python permutation_analysis.py \
+    --statistical_method $STAT_METHOD \
+    --start_sim $beg --end_sim $end \
+    --beta $BETA --gamma $GAMMA" &
   count=$((count+1))
 done
 wait


### PR DESCRIPTION
## Summary
- source conda inside `srun` jobs so compute nodes use the `openBINN` env

## Testing
- `pytest -q openbinn/explainers/catalog/lime/lime_package/tests/test_lime_tabular.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6844304faabc83228442213fd097bd2f