### PR TITLE
Fix missing argparse import in train_original.py

### DIFF
--- a/analysis/train_original.py
+++ b/analysis/train_original.py
@@ -11,6 +11,7 @@ datasets.
 import os
 import time
 import warnings
+import argparse
 from pathlib import Path
 from itertools import product
 


### PR DESCRIPTION
## Summary
- import argparse to avoid NameError

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68443afd16188322a7a7bf9d9886ddb2