### PR TITLE
Fix missing argparse import in train_original.py

### DIFF
--- a/analysis/train_original.py
+++ b/analysis/train_original.py
@@ -11,6 +11,7 @@ datasets.
 import os
 import time
 import warnings
+import argparse
 from pathlib import Path
 from itertools import product
 
@@ -113,7 +114,7 @@ def train_dataset(scen_dir: Path, reactome, best_params=None):
     metrics_fp   = results_root/"optimal"/"metrics.csv"
 
     if metrics_fp.exists() and best_params is None:
-        print(f"[skip] already trained → {scen_dir.relative_to(DATA_ROOT)}")
+        print(f"[skip] already trained → {scen_dir.relative_to(DATA_ROOT.parent)}")
         best_params = load_best_params(metrics_fp)
     
 
@@ -129,7 +130,7 @@ def train_dataset(scen_dir: Path, reactome, best_params=None):
         summary_rows = []
         for lr, bs in product(LR_LIST, BS_LIST):
             tag = f"lr_{lr:g}_bs_{bs}"
-            print(f"      Grid ▶ {scen_dir.relative_to(DATA_ROOT)} | {tag}")
+            print(f"      Grid ▶ {scen_dir.relative_to(DATA_ROOT.parent)} | {tag}")
 
             tr_loader = GeoLoader(ds, bs,
                                   sampler=SubsetRandomSampler(ds.train_idx),


### PR DESCRIPTION
## Summary
- import argparse to avoid NameError
- use data root parent when printing paths

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68443afd16188322a7a7bf9d9886ddb2