### PR TITLE
Persist trained models for reuse in experiment 1

### DIFF
--- a/analysis/experiment1_constants.py
+++ b/analysis/experiment1_constants.py
@@ -1,0 +1,21 @@
+"""Common constants for experiment 1 scripts.
+
+These constants define shared directory names and model filenames so that
+related scripts can build paths consistently without hardcoding values.
+"""
+
+# Directory names
+RESULTS_DIR = "results"
+OPTIMAL_DIR = "optimal"
+EXPLANATIONS_DIR = "explanations"
+
+# Model filenames
+LOGISTIC_MODEL_FILENAME = "logistic_model.joblib"
+FCNN_MODEL_FILENAME = "fcnn_model.pth"
+PNET_MODEL_FILENAME = "trained_model.pth"
+PNET_CONFIG_FILENAME = "best_params.json"
+
+# Hyperparameters
+FCNN_HIDDEN_DIM = 128
+DEFAULT_BATCH_SIZE = 32
+

--- a/analysis/fnn_experiment1.py
+++ b/analysis/fnn_experiment1.py
@@ -94,8 +94,14 @@ def main():
     ds, x, y = load_dataset(data_dir)
     x_tr, y_tr = x[ds.train_idx], y[ds.train_idx]
 
-    model = train_fnn(x_tr, y_tr)
+    hidden_dim = 128
+    model = train_fnn(x_tr, y_tr, hidden_dim=hidden_dim)
     model.eval()
+
+    # save trained model for later evaluation/comparison
+    opt_dir = data_dir / "results" / "optimal"
+    opt_dir.mkdir(parents=True, exist_ok=True)
+    torch.save({"state_dict": model.state_dict(), "hidden_dim": hidden_dim}, opt_dir / "fcnn_model.pth")
 
     x_te = torch.from_numpy(x[ds.test_idx]).float()
     y_te = torch.from_numpy(y[ds.test_idx]).long()

--- a/analysis/fnn_experiment1.py
+++ b/analysis/fnn_experiment1.py
@@ -11,6 +11,14 @@ from pathlib import Path
 import argparse
 import sys
 
+from experiment1_constants import (
+    RESULTS_DIR,
+    OPTIMAL_DIR,
+    EXPLANATIONS_DIR,
+    FCNN_MODEL_FILENAME,
+    FCNN_HIDDEN_DIM,
+)
+
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
@@ -58,7 +66,7 @@ def load_dataset(data_dir: Path):
     return ds, x, y
 
 
-def train_fnn(x_train, y_train, hidden_dim=128, epochs=50, batch_size=32, lr=1e-3):
+def train_fnn(x_train, y_train, hidden_dim=FCNN_HIDDEN_DIM, epochs=50, batch_size=32, lr=1e-3):
     torch.manual_seed(SEED)
     input_dim = x_train.shape[1]
     model = nn.Sequential(
@@ -94,14 +102,14 @@ def main():
     ds, x, y = load_dataset(data_dir)
     x_tr, y_tr = x[ds.train_idx], y[ds.train_idx]
 
-    hidden_dim = 128
+    hidden_dim = FCNN_HIDDEN_DIM
     model = train_fnn(x_tr, y_tr, hidden_dim=hidden_dim)
     model.eval()
 
     # save trained model for later evaluation/comparison
-    opt_dir = data_dir / "results" / "optimal"
+    opt_dir = data_dir / RESULTS_DIR / OPTIMAL_DIR
     opt_dir.mkdir(parents=True, exist_ok=True)
-    torch.save({"state_dict": model.state_dict(), "hidden_dim": hidden_dim}, opt_dir / "fcnn_model.pth")
+    torch.save({"state_dict": model.state_dict(), "hidden_dim": hidden_dim}, opt_dir / FCNN_MODEL_FILENAME)
 
     x_te = torch.from_numpy(x[ds.test_idx]).float()
     y_te = torch.from_numpy(y[ds.test_idx]).long()
@@ -109,7 +117,7 @@ def main():
 
     n_genes = len(ds.node_index)
     n_feat = ds.x.shape[2]
-    explain_root = data_dir / "results" / "explanations" / "FCNN"
+    explain_root = data_dir / RESULTS_DIR / EXPLANATIONS_DIR / "FCNN"
     explain_root.mkdir(parents=True, exist_ok=True)
     config = utils.load_config(str(ROOT / "configs/experiment_config.json"))
     data_label = data_dir.name

--- a/analysis/logistic_experiment1.py
+++ b/analysis/logistic_experiment1.py
@@ -20,6 +20,7 @@ if str(ROOT) not in sys.path:
 import numpy as np
 import pandas as pd
 from sklearn.linear_model import LogisticRegression
+import joblib
 
 from openbinn.binn.data import PnetSimDataSet, ReactomeNetwork, get_layer_maps
 
@@ -72,6 +73,12 @@ def main():
     x_tr, y_tr = x[ds.train_idx], y[ds.train_idx]
 
     model = train_logistic(x_tr, y_tr)
+
+    # save trained model for later evaluation/comparison
+    opt_dir = data_dir / "results" / "optimal"
+    opt_dir.mkdir(parents=True, exist_ok=True)
+    joblib.dump(model, opt_dir / "logistic_model.joblib")
+
     n_genes = len(ds.node_index)
     n_feat = ds.x.shape[2]
     beta = model.coef_[0].reshape(n_genes, n_feat).sum(axis=1)

--- a/analysis/logistic_experiment1.py
+++ b/analysis/logistic_experiment1.py
@@ -11,6 +11,13 @@ from pathlib import Path
 import argparse
 import sys
 
+from experiment1_constants import (
+    RESULTS_DIR,
+    OPTIMAL_DIR,
+    EXPLANATIONS_DIR,
+    LOGISTIC_MODEL_FILENAME,
+)
+
 # ensure repository root is on sys.path so ``openbinn`` can be imported when
 # executing this script from within the ``analysis`` directory
 ROOT = Path(__file__).resolve().parents[1]
@@ -75,15 +82,15 @@ def main():
     model = train_logistic(x_tr, y_tr)
 
     # save trained model for later evaluation/comparison
-    opt_dir = data_dir / "results" / "optimal"
+    opt_dir = data_dir / RESULTS_DIR / OPTIMAL_DIR
     opt_dir.mkdir(parents=True, exist_ok=True)
-    joblib.dump(model, opt_dir / "logistic_model.joblib")
+    joblib.dump(model, opt_dir / LOGISTIC_MODEL_FILENAME)
 
     n_genes = len(ds.node_index)
     n_feat = ds.x.shape[2]
     beta = model.coef_[0].reshape(n_genes, n_feat).sum(axis=1)
 
-    exp_dir = data_dir / "results" / "explanations" / "Logistic"
+    exp_dir = data_dir / RESULTS_DIR / EXPLANATIONS_DIR / "Logistic"
     exp_dir.mkdir(parents=True, exist_ok=True)
     df = pd.DataFrame({"gene": ds.node_index, "importance": beta})
     df.to_csv(exp_dir / "logistic_beta.csv", index=False)


### PR DESCRIPTION
## Summary
- Save trained logistic regression and FCNN models during experiment1 runs
- Load previously trained models for performance comparison instead of retraining

## Testing
- `python -m py_compile analysis/logistic_experiment1.py analysis/fnn_experiment1.py analysis/model_comparison.py`

------
https://chatgpt.com/codex/tasks/task_e_68a1b69035608322b5b5f9eabc0199ff